### PR TITLE
Revert changes to escaped characters introduced in commit 2edd8db.

### DIFF
--- a/src/examples/buffered_dummy_example.py
+++ b/src/examples/buffered_dummy_example.py
@@ -90,7 +90,7 @@ buffer_settings = {
 }
 
 # %% Measurement Setup
-# with open(r"C:\Users	ill3\Documents\PythonScripts\Test Measurements	estsettings.yaml") as file:
+# with open(r"C:\Users\till3\Documents\PythonScripts\Test Measurements\testsettings.yaml") as file:
 #     parameters = yaml.safe_load(file)
 parameters = {
     "dmm": {"voltage": {"type": "gettable"}},

--- a/src/examples/buffered_example1.py
+++ b/src/examples/buffered_example1.py
@@ -67,8 +67,7 @@ station = Station()
 # ramp methods or add_mapping_to_instrument(instrument, path) for instruments without
 # to map the instrument's parameters to QuMADA-specific names.
 
-dac = Decadac("dac", "ASRL6::INSTR", min_val=-10, max_val=10, terminator="
-")
+dac = Decadac("dac", "ASRL6::INSTR", min_val=-10, max_val=10, terminator="\n")
 add_mapping_to_instrument(dac, mapping=DecadacMapping())
 station.add_component(dac)
 


### PR DESCRIPTION
Revert all changes to escaped characters that were introduced in commit 2edd8db.
Some escaped characters were changed in already removed files (legacy) and some changes were already fixed.