### PR TITLE
fix packaging errors

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,6 +3,7 @@ __pycache__/
 *.egg-info/
 
 dist/
+build/
 
 # generated images / documents
 *.png

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -38,7 +38,13 @@ Documentation = "https://qumada.readthedocs.io/en/latest/"
 requires = ["setuptools"]
 build-backend = "setuptools.build_meta"
 
+[tool.setuptools.package-data]
+qumada = ["*.json"]
+
 [tool.pytest.ini_options]
+addopts = [
+    "--import-mode=importlib",
+]
 qt_api = "pyqt5"
 
 [tool.black]

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,8 +1,3 @@
-[options]
-package_dir =
-    = src
-packages = find:
-
 [pylint.master]
 max-line-length = 120
 ignore = FZJ_Decadac.py,Example_measurements.py,SET_testing.py


### PR DESCRIPTION
qumada was not importable due to setuptools misconfiguration.
Also, all mapping json files were missing in built qumada.

Closes #29.