### PR TITLE
add docs building to tox

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,6 +73,12 @@ python -m pre-commit install
 To build the documentation, run:
 
 ```
+tox -e docs
+```
+
+or
+
+```
 cd docs
 make html
 ```

--- a/docs/installation.rst
+++ b/docs/installation.rst
@@ -70,7 +70,7 @@ Run
 or
 
 .. code-block:: console
-    
+
     cd docs
     make html
 

--- a/docs/installation.rst
+++ b/docs/installation.rst
@@ -65,6 +65,12 @@ Run
 
 .. code-block:: console
 
+    tox -e docs
+
+or
+
+.. code-block:: console
+    
     cd docs
     make html
 

--- a/tox.ini
+++ b/tox.ini
@@ -3,6 +3,7 @@ envlist =
     py{39,310,311}
     report
     lint
+    docs
 
 [tool:pytest]
 testpaths = src/tests
@@ -36,3 +37,9 @@ deps =
     pylint-gitlab
 commands =
     pylint src {posargs}
+
+[testenv:docs]
+deps =
+    -rdocs{/}requirements.txt
+commands =
+    sphinx-build docs docs{/}_build -bhtml {posargs}


### PR DESCRIPTION
For ease of use, build documentation using tox:

```
tox -e docs
```

Closes #22.