### PR TITLE
Remove "path" argument from add_mapping_to_instrument

### DIFF
--- a/src/qumada/instrument/mapping/base.py
+++ b/src/qumada/instrument/mapping/base.py
@@ -144,8 +144,7 @@ def _load_instrument_mapping(path: str) -> Any:
 def add_mapping_to_instrument(
     instrument: Instrument,
     *,
-    path: str | None = None,
-    mapping: InstrumentMapping | None = None,
+    mapping: InstrumentMapping | str | None = None,
 ) -> None:
     """
     Loads instrument mapping from mapping JSON file and adds it as instrument attribute.
@@ -156,10 +155,10 @@ def add_mapping_to_instrument(
 
     Args:
         instrument (Instrument): Instrument, the mapping is added to.
-        path (str): Path to the JSON file.
-        mapping (InstrumentMapping): mapping object
+        mapping (InstrumentMapping | str): Either mapping object or path to json file
+                                           with mapping.
     """
-    if path is None and mapping is not None:
+    if isinstance(mapping, InstrumentMapping):
         helper_mapping = mapping.mapping
         instrument._qumada_ramp = mapping.ramp
         instrument._is_triggerable = mapping._is_triggerable
@@ -168,12 +167,12 @@ def add_mapping_to_instrument(
             instrument._qumada_trigger = mapping.trigger
         except:
             pass
-        # TODO: Better name??
-    elif path is not None and mapping is None:
-        helper_mapping = _load_instrument_mapping(path)
+    elif isinstance(mapping, str):
+        helper_mapping = _load_instrument_mapping(mapping)
         instrument._is_triggerable = False
     else:
-        raise ValueError("Arguments 'path' and 'mapping' are exclusive.")
+        raise ValueError("Mapping parameter has to be either of type \
+                         InstrumentMapping or str")
 
     mapping = {}
     mapping["parameter_names"] = {

--- a/src/qumada/instrument/mapping/base.py
+++ b/src/qumada/instrument/mapping/base.py
@@ -171,8 +171,10 @@ def add_mapping_to_instrument(
         helper_mapping = _load_instrument_mapping(mapping)
         instrument._is_triggerable = False
     else:
-        raise ValueError("Mapping parameter has to be either of type \
-                         InstrumentMapping or str")
+        raise ValueError(
+            "Mapping parameter has to be either of type \
+                         InstrumentMapping or str"
+        )
 
     mapping = {}
     mapping["parameter_names"] = {

--- a/src/tests/mapping_test.py
+++ b/src/tests/mapping_test.py
@@ -47,7 +47,7 @@ from qumada.measurement.scripts.generic_measurement import Generic_1D_Sweep
 @pytest.fixture(name="dmm", scope="session")
 def fixture_dmm():
     dmm = DummyDmm("dmm")
-    add_mapping_to_instrument(dmm, path=mapping.DUMMY_DMM_MAPPING)
+    add_mapping_to_instrument(dmm, mapping=mapping.DUMMY_DMM_MAPPING)
     return dmm
 
 
@@ -61,7 +61,7 @@ def fixture_dac():
 @pytest.fixture(name="dci", scope="session")
 def fixture_dci():
     dci = DummyChannelInstrument("dci")
-    add_mapping_to_instrument(dci, path=mapping.DUMMY_CHANNEL_MAPPING)
+    add_mapping_to_instrument(dci, mapping=mapping.DUMMY_CHANNEL_MAPPING)
     return dci
 
 
@@ -168,7 +168,7 @@ def test_instrument_mapping(mocker: MockerFixture, valid_mapping_data):
     )
     path = "pathtomapping.json"
 
-    add_mapping_to_instrument(instr, path=path)
+    add_mapping_to_instrument(instr, mapping=path)
 
     for parameter in [instr.v1, instr.v2]:
         assert parameter._mapping == "voltage"


### PR DESCRIPTION
So far different kwargs were required depending on whether a mapping class or mapping json was used.
Now add_mapping_to_instrument only takes the mapping argument for both cases.